### PR TITLE
ability to pull questions from API

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,40 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import reactLogo from './assets/react.svg'
 import './App.css'
 import Start from './components/Start'
 import Questions from './components/Questions'
+import { nanoid } from 'nanoid'
+
 
 function App() {
   const [isStarted, setIsStarted] = useState(false)
+  const [questions, setQuestions] = useState([])
 
+//on initial load, acquire a set of trivia questions
+//never need to run this again
+  useEffect(()=>{
+      console.log("in useEffect")
+      const url = "https://opentdb.com/api.php?amount=5&difficulty=easy"
+      fetch(url).then((response)=>response.json())
+        .then((data)=>setQuestions(data.results.map((item)=>(
+          {
+            ...item,
+            id: nanoid()
+          }
+        )
+
+        )))
+    }
+    ,[]
+  )
+
+// switch from the Start component to the Questions component being displayed
   function startQuiz(){
     setIsStarted(true)
   }
+  
+  return isStarted ? <Questions data={questions} /> : <Start onClick={startQuiz} />
 
-  return (
-     isStarted ? <Questions /> : <Start onClick={startQuiz}/>
-  )
 }
 
 export default App

--- a/src/components/Question.jsx
+++ b/src/components/Question.jsx
@@ -1,0 +1,59 @@
+import React , {useState} from "react"
+import { nanoid } from 'nanoid'
+
+export default function Question(props){
+    //This component receives a single question
+    const [question, setQuestion] = React.useState(props.question)
+    const [answers, setAnswers] = React.useState( getAnswerOptions())
+
+    //the questions and answers will arrive with special characters
+    //encoded as HTML e.g. &#49; or some such
+    //must decode them so they will display properly
+    function decodeString(htmlCodeString){
+        let elem = document.createElement('textarea');
+        elem.innerHTML = htmlCodeString;
+        return elem.value;        
+    }
+
+    //the answers arrive split into a group of incorrect answers
+    //and a separate listing of the correct answer
+    //must mix them together into one list to display
+    function getAnswerOptions(){
+        let answers = question.incorrect_answers.map((a)=> {
+            return {
+                answer: a,
+                correct: false,
+                selected: false,
+                id: nanoid() 
+            }
+        })
+        answers.push({
+            answer: question.correct_answer,
+            correct: true,
+            selected: false,
+            id: nanoid() 
+    })
+        //sort alphabetically since that should be fairly random
+        answers.sort(( a, b )=> {
+            if ( a.answer < b.answer ){
+              return -1;
+            }
+            if ( a.answer > b.answer ){
+              return 1;
+            }
+            return 0;
+          })
+          return answers
+    }
+
+
+    return (
+        <article className="question">
+            <h2 className="question--title">{decodeString(question.question)}</h2>
+            <div className="question--answers">
+                {answers.map((answer)=><button key={answer.id}>{decodeString(answer.answer)}</button>)}
+            </div>
+        </article>
+
+    )
+}

--- a/src/components/Questions.jsx
+++ b/src/components/Questions.jsx
@@ -1,9 +1,13 @@
-import React from "react"
+import React , {useState} from "react"
+import questionlist from "./data"
+import Question from "./Question"
 
-export default function Questions(){
+
+export default function Questions(props){
+
     return(
         <div className="App">
-            <h1>Questions will appear here</h1>
+            {questionlist.data.map((item)=>(<Question key={item.id} question={item}/>))}
         </div>
     )
 }

--- a/src/components/data.js
+++ b/src/components/data.js
@@ -1,0 +1,53 @@
+export default {
+  data: [
+    {
+      category: "History",
+      type: "multiple",
+      difficulty: "medium",
+      question:
+        "Which of the following is NOT classified as a Semetic language?",
+      correct_answer: "Sumerian",
+      incorrect_answers: ["Maltese", "Akkadian", "Mandaic"],
+      id: 1
+    },
+    {
+      category: "Entertainment: Music",
+      type: "multiple",
+      difficulty: "medium",
+      question:
+        "Which of these artists was NOT a member of the electronic music supergroup Swedish House Mafia, which split up in 2013?",
+      correct_answer: "Alesso",
+      incorrect_answers: ["Steve Angello", "Sebastian Ingrosso", "Axwell"],
+      id: 2
+    },
+    {
+      category: "Entertainment: Television",
+      type: "multiple",
+      difficulty: "medium",
+      question:
+        "Which of the following was not an actor/actress on the American television show &quot;Saturday Night Live&quot; in Season 42?",
+      correct_answer: "Tina Fey",
+      incorrect_answers: ["Mikey Day", "Kate McKinnon", "Sasheer Zamata"],
+      id: 3
+    },
+    {
+      category: "Entertainment: Japanese Anime & Manga",
+      type: "multiple",
+      difficulty: "easy",
+      question: "Who is the main heroine of the anime, Full Metal Panic!",
+      correct_answer: "Kaname Chidori",
+      incorrect_answers: ["Teletha Testarossa", "Melissa Mao", "Kyoko Tokiwa"],
+      id: 4
+    },
+    {
+      category: "Entertainment: Video Games",
+      type: "multiple",
+      difficulty: "medium",
+      question:
+        "Which of the following Terran units from the RTS game Starcraft was first introduced in the expansion Brood War?",
+      correct_answer: "Medic",
+      incorrect_answers: ["Wraith", "Science Vessel", "SCV"],
+      id: 5
+    },
+  ],
+};


### PR DESCRIPTION
Closes #4 
Currently configured to use questionlist static data but can easily switch out questionlist for props in which case it will use live data pulled from the API. 